### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/Magnified Pictures/Magnified_Pictures/app/src/main/AndroidManifest.xml
+++ b/Magnified Pictures/Magnified_Pictures/app/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@drawable/logo"
 
         android:label="Magnified Pictures


### PR DESCRIPTION
For allow: Backup always set to false if it is true, this is considered a security issue because people could backup your app via ADB and then get private data of your app into their PC.